### PR TITLE
Fix #41 & Update to newest Synthesis

### DIFF
--- a/AllGUDMeshGen/AllGUDMeshGen.csproj
+++ b/AllGUDMeshGen/AllGUDMeshGen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <Version>1.17.0</Version>
   </PropertyGroup>
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.1" />
-    <PackageReference Include="Mutagen.Bethesda" Version="0.34.1" />
-    <PackageReference Include="Mutagen.Bethesda.Core" Version="0.34.1" />
-    <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="2.1.0" />
-    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.21.4" />
-    <PackageReference Include="niflysharp" Version="1.2.9" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.6" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.39.6" />
+    <PackageReference Include="Mutagen.Bethesda.Core" Version="0.39.6" />
+    <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="3.0.0" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.24.0" />
+    <PackageReference Include="niflysharp" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AllGUDMeshGen/MeshHandler.cs
+++ b/AllGUDMeshGen/MeshHandler.cs
@@ -290,7 +290,7 @@ namespace AllGUD
                 // skip if no record or Model
                 if (target == null || target.Model == null)
                     continue;
-                string modelPath = target.Model.File.ToLower();
+                string modelPath = target.Model.File.RawPath.ToLower();
                 if (modelPath.Contains("weapon", StringComparison.OrdinalIgnoreCase) ||
                     modelPath.Contains("armor", StringComparison.OrdinalIgnoreCase))
                 {

--- a/PatcherTest/PatcherTest.csproj
+++ b/PatcherTest/PatcherTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Fixes a compilation error on newer versions of Synthesis that appeared due to changes in the API:
```
AllGUDMeshGen\AllGUDMeshGen\MeshHandler.cs(293,54,293,61): error CS7036: There is no argument given that corresponds to the required formal parameter 'destination' of 'MemoryExtensions.ToLower(ReadOnlySpan<char>, Span<char>, CultureInfo?)'
```

It also updates all of the Synthesis nuget packages to the latest stable versions in addition to migrating both projects to .NET 6